### PR TITLE
    feat: Allow specifying merge method on /merge     

### DIFF
--- a/.tekton/boussole.yaml
+++ b/.tekton/boussole.yaml
@@ -5,7 +5,7 @@ metadata:
   name: boussole
   annotations:
     pipelinesascode.tekton.dev/pipeline: ".tekton/pipelines/in-repo.yaml"
-    pipelinesascode.tekton.dev/on-comment: "^/(help|rebase|merge|lgtm|(cherry-pick|assign|unassign|label|unlabel) )"
+    pipelinesascode.tekton.dev/on-comment: "^/(help|rebase|lgtm|(cherry-pick|assign|merge|unassign|label|unlabel)[ ].*)"
     pipelinesascode.tekton.dev/max-keep-runs: "2"
 spec:
   params:
@@ -29,6 +29,10 @@ spec:
       value: "{{ git_auth_secret }}"
     - name: comment_sender
       value: "{{ sender }}"
+    # The merge method to use. Can be one of: merge, squash, rebase
+    - name: merge_method
+      value: "squash"
+
   pipelineRef:
     name: in-repo
   workspaces:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ automated actions.
 | `/unlabel bug feature`       | Removes labels from the PR                                      |
 | `/cherry-pick target-branch` | Cherry-picks the PR changes to the target branch on merge      |
 | `/lgtm`                      | Approves the PR if at least one org member has commented `/lgtm` |
-| `/merge`                     | Merges the PR if it has enough `/lgtm` approvals               |
+| `/merge [method]`            | Merges the PR if it has enough `/lgtm` approvals. Optional method: `merge`, `squash`, or `rebase` |
 | `/rebase`                    | Rebases the PR branch on the base branch                        |
 | `/help`                      | Displays available commands                                     |
 
@@ -54,7 +54,7 @@ metadata:
   name: boussole
   annotations:
     pipelinesascode.tekton.dev/pipeline: "https://raw.githubusercontent.com/openshift-pipelines/pac-boussole/main/pipeline-boussole.yaml"
-    pipelinesascode.tekton.dev/on-comment: "^/(help|rebase|merge|lgtm|(cherry-pick|assign|unassign|label|unlabel)[ ].*)$"
+    pipelinesascode.tekton.dev/on-comment: "^/(help|rebase|lgtm|(cherry-pick|assign|merge|unassign|label|unlabel)[ ].*)"
     pipelinesascode.tekton.dev/max-keep-runs: "2"
 spec:
   params:

--- a/boussole/messages.py
+++ b/boussole/messages.py
@@ -11,7 +11,7 @@ HELP_TEXT = f"""
 | `/label bug feature`        | Adds labels to the PR                                                           |
 | `/unlabel bug feature`      | Removes labels from the PR                                                      |
 | `/lgtm`                     | Approves the PR if at least {LGTM_THRESHOLD} org members have commented `/lgtm` |
-| `/merge`                    | Merges the PR if it has enough `/lgtm` approvals                                |
+| `/merge [method]`           | Merges the PR if it has enough `/lgtm` approvals. Optional method: merge, squash, or rebase |
 | `/cherry-pick target-branch`| Cherry-picks the PR changes to the target branch                                |
 | `/rebase`                   | Rebases the PR branch on the base branch                                        |
 | `/help`                     | Shows this help message                                                         |

--- a/pipeline-boussole.yaml
+++ b/pipeline-boussole.yaml
@@ -5,7 +5,7 @@ metadata:
   name: boussole
   annotations:
     pipelinesascode.tekton.dev/on-comment: |
-      ^/(help|rebase|merge|lgtm|(cherry-pick|assign|unassign|label|unlabel)[ ].*)$
+      ^/(help|rebase|lgtm|(cherry-pick|assign|merge|unassign|label|unlabel)[ ].*)$
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
   params:


### PR DESCRIPTION

    This change allows users to specify a merge method (merge, squash,
    rebase) when using the `/merge` command. It updates the boussole.py
    script to accept an optional merge method parameter and modifies the
    regex to include merge. The default merge method is squash. This
    commit also updates the README.md and messages.py to reflect the new
    functionality. Additionally, a test case has been added to verify the
    functionality.
 