### PR TITLE
feat: Exclude bot users from LGTM users table

### DIFF
--- a/boussole/boussole.py
+++ b/boussole/boussole.py
@@ -468,6 +468,8 @@ class PRHandler:  # pylint: disable=too-many-instance-attributes
                 users_table = ""
                 for user, permission in lgtm_users.items():
                     is_valid = permission in self.lgtm_permissions
+                    if "[bot]" in user:
+                        continue
                     valid_mark = "✅" if is_valid else "❌"
                     users_table += (
                         f"| @{user} | `{permission or 'unknown'}` | {valid_mark} |\n"


### PR DESCRIPTION
This change filters out bot users from appearing in the
generated LGTM users table. This is achieved by checking if
the username contains "[bot]" and skipping the user if it does,
resulting in a cleaner and more relevant table for human
reviewers.
