### PR TITLE
feat: allow cherry-pick on merged PRs

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -11,6 +11,9 @@ on:
     paths:
       - "boussole/**"
 
+permissions:
+  packages: write
+
 jobs:
   build-multi-arch-image:
     runs-on: ubuntu-latest

--- a/.tekton/pipelines/in-repo.yaml
+++ b/.tekton/pipelines/in-repo.yaml
@@ -44,7 +44,7 @@ spec:
               - name: revision
                 value: "$(params.revision)"
           - name: manage-pr
-            image: ghcr.io/openshift-pipelines/pac-boussole:nightly
+            image: ghcr.io/pipelines-as-code/pac-boussole:nightly
             workingDir: $(workspaces.source.path)
             env:
               - name: GITHUB_TOKEN

--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,14 @@ CMD =
 ARGS=
 UVCMD = uv run
 PIPELINE_PROW = pipeline-boussole.yaml
-GH_REPO_OWNER = openshift-pipelines
+GH_REPO_OWNER = pipelines-as-code
 GH_REPO_NAME = pac-boussole
 GH_PR_NUM = 44
 GH_PR_SENDER = anotheruser
 GH_COMMENT_SENDER = chmouel
 PASS_TOKEN = github/chmouel-token
 PRURL = https://github.com/$(GH_REPO_OWNER)/$(GH_REPO_NAME)/pull/$(GH_PR_NUM)
-CONTAINER_IMAGE = ghcr.io/openshift-pipelines/pac-boussole:nightly
+CONTAINER_IMAGE = ghcr.io/pipelines-as-code/pac-boussole:nightly
 PYTEST = pytest
 PYLINT = pylint
 PYTEST_ARGS = --cov=boussole --cov-report=term

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ kind: PipelineRun
 metadata:
   name: boussole
   annotations:
-    pipelinesascode.tekton.dev/pipeline: "https://raw.githubusercontent.com/openshift-pipelines/pac-boussole/main/pipeline-boussole.yaml"
+    pipelinesascode.tekton.dev/pipeline: "https://raw.githubusercontent.com/pipelines-as-code/pac-boussole/main/pipeline-boussole.yaml"
     pipelinesascode.tekton.dev/on-comment: "^/(help|rebase|lgtm|cherry-pick|assign|merge|unassign|label|unlabel)"
     pipelinesascode.tekton.dev/max-keep-runs: "2"
 spec:

--- a/boussole/boussole.py
+++ b/boussole/boussole.py
@@ -335,9 +335,12 @@ class PRHandler:  # pylint: disable=too-many-instance-attributes
             self.api.delete(f"issues/{self.pr_num}/labels/{label}")
         return self._post_comment(f"✅ Removed labels: <b>{', '.join(labels)}</b>.")
 
-    def cherry_pick(self, values: List[str]) -> None:
+    def cherry_pick(self, values: List[str], immediate: bool = False) -> None:
         """
-        Posts a comment indicating the PR will be cherry-picked to the specified branch.
+        Handles cherry-pick command.
+
+        When immediate=False (PR is open): checks permissions, posts an info comment.
+        When immediate=True (PR is merged): checks merged state, permissions, then performs cherry-pick.
         """
         if len(values) != 1:
             print(
@@ -347,9 +350,32 @@ class PRHandler:  # pylint: disable=too-many-instance-attributes
             sys.exit(1)
 
         target_branch = values[0]
-        self._post_comment(
-            f"✅ We will cherry-pick this PR to the branch `{target_branch}` upon merge."
-        )
+
+        permission, is_valid = self._check_membership(self.comment_sender)
+        if not is_valid:
+            msg = INSUFFICIENT_PERMISSIONS.format(
+                user=self.comment_sender,
+                permission=permission,
+                required_permissions=", ".join(self.lgtm_permissions),
+            )
+            self._post_comment(msg)
+            print(msg, file=sys.stderr)
+            sys.exit(1)
+
+        if not immediate:
+            self._post_comment(
+                f"✅ We will cherry-pick this PR to the branch `{target_branch}` upon merge."
+            )
+            return
+
+        pr_status = self._get_pr_status(self.pr_num).json()
+        if not pr_status.get("merged"):
+            msg = f"⚠️ PR #{self.pr_num} is closed but not merged. Cannot cherry-pick."
+            self._post_comment(msg)
+            print(msg, file=sys.stderr)
+            sys.exit(1)
+
+        self._perform_cherry_pick(target_branch)
 
     def rebase(self) -> RequestResponse:
         endpoint = f"pulls/{self.pr_num}/update-branch"
@@ -438,7 +464,7 @@ class PRHandler:  # pylint: disable=too-many-instance-attributes
         # Fetch LGTM votes
         valid_votes, lgtm_users = self._fetch_and_validate_lgtm_votes()
         # Handle case where admin/write user can merge directly
-        if self.pr_sender not in self.comment_sender and permission in [
+        if self.pr_sender != self.comment_sender and permission in [
             "admin",
             "write",
         ]:
@@ -796,7 +822,9 @@ def main():
     command, values = match.groups()
     values = values.split()
 
-    if not pr_handler.check_status(args.pr_num, "open"):
+    pr_is_open = pr_handler.check_status(args.pr_num, "open")
+
+    if not pr_is_open and command != "cherry-pick":
         print(f"⚠️ PR #{args.pr_num} is not open.", file=sys.stderr)
         sys.exit(1)
 
@@ -814,7 +842,6 @@ def main():
     elif command == "lgtm":
         pr_handler.lgtm()
     elif command == "merge":
-        # Pass custom merge method if provided
         merge_method = (
             values[0]
             if values and values[0].lower() in ["merge", "squash", "rebase"]
@@ -822,7 +849,7 @@ def main():
         )
         pr_handler.merge_pr(merge_method)
     elif command == "cherry-pick":
-        pr_handler.cherry_pick(values)
+        pr_handler.cherry_pick(values, immediate=not pr_is_open)
 
     if response:
         if not pr_handler.check_response(response):

--- a/boussole/messages.py
+++ b/boussole/messages.py
@@ -26,7 +26,7 @@ Congrats @{pr_sender} your PR Has been approved 🎉
 
 ### ✅ Pull Request Approved
 
-*Approval Status:* 
+*Approval Status:*
 * Required Approvals: {threshold}
 * Current Approvals: {valid_votes}
 
@@ -119,7 +119,7 @@ Unable to process LGTM votes due to API error:
 * Status Code: `{status_code}`
 * Response: `{response_text}`
 
-*Troubleshooting Steps:* 
+*Troubleshooting Steps:*
 1. Check your authentication token
 2. Verify PR number: `{pr_num}`
 3. Ensure the PR hasn't been closed or deleted
@@ -233,7 +233,7 @@ Successfully cherry-picked changes from PR #{source_pr} to branch `{target_branc
 """
 
 CHERRY_PICK_CONFLICT = """
-🚨 Merge conflict detected while cherry-picking PR #{self.pr_num} to {target_branch}
+🚨 Merge conflict detected while cherry-picking PR #{pr_num} to {target_branch}
 • Progress: {current_commit}/{total_commits} commits
 • Conflicting commit: {commit_sha}
 
@@ -241,7 +241,7 @@ To resolve this conflict:
 1. Create a new branch from {target_branch}
 
 ```shell
-git checkout -b resolve-cherry-pick-{self.pr_num} origin/{target_branch}
+git checkout -b resolve-cherry-pick-{pr_num} origin/{target_branch}
 ```
 
 2. Cherry-pick the commits manually using:
@@ -254,8 +254,8 @@ git cherry-pick {commit_sha}
 4. Create a new PR with your changes
 
 ```shell
-git push YOURFORKREMOTE resolve-cherry-pick-{self.pr_num} --force-with-lease
-gh pr create --base {target_branch} --head YOURFORK:resolve-cherry-pick-{self.pr_num}
+git push YOURFORKREMOTE resolve-cherry-pick-{pr_num} --force-with-lease
+gh pr create --base {target_branch} --head YOURFORK:resolve-cherry-pick-{pr_num}
 
 ```
 

--- a/boussole/messages.py
+++ b/boussole/messages.py
@@ -17,7 +17,7 @@ HELP_TEXT = f"""
 | `/help`                     | Shows this help message                                                         |
 
 
-*Automated by the [PAC Boussole](https://github.com/openshift-pipelines/pac-boussole) 🧭* 
+*Automated by the [PAC Boussole](https://github.com/pipelines-as-code/pac-boussole) 🧭*
 
 """
 
@@ -42,7 +42,7 @@ Congrats @{pr_sender} your PR Has been approved 🎉
 directly if you have repository permission).
 
 
-*Automated by the [PAC Boussole](https://github.com/openshift-pipelines/pac-boussole) 🧭* 
+*Automated by the [PAC Boussole](https://github.com/pipelines-as-code/pac-boussole) 🧭*
 
 """
 
@@ -52,13 +52,13 @@ LGTM_BREAKDOWN_TEMPLATE = """
 * **Current valid votes:** {valid_votes}/{threshold}
 * **Voting required for approval:** {threshold}
 
-*Votes Summary:* 
+*Votes Summary:*
 | Reviewer | Permission | Valid Vote |
 |----------|------------|------------|
 {users_table}
 
 
-*Automated by the [PAC Boussole](https://github.com/openshift-pipelines/pac-boussole) 🧭* 
+*Automated by the [PAC Boussole](https://github.com/pipelines-as-code/pac-boussole) 🧭*
 
 """
 
@@ -77,7 +77,7 @@ SUCCESS_MERGED = """
 
 Thank you @{pr_sender} for your valuable contribution! 🎉
 
-*Automated by the [PAC Boussole](https://github.com/openshift-pipelines/pac-boussole) 🧭* 
+*Automated by the [PAC Boussole](https://github.com/pipelines-as-code/pac-boussole) 🧭*
 
 """
 
@@ -95,7 +95,7 @@ Unable to verify permissions for user **@{user}**
 Please check user permissions and try again.
 
 
-*Automated by the [PAC Boussole](https://github.com/openshift-pipelines/pac-boussole) 🧭* 
+*Automated by the [PAC Boussole](https://github.com/pipelines-as-code/pac-boussole) 🧭*
 
 """
 
@@ -108,7 +108,7 @@ Failed to retrieve permission level for user **@{user}**
 * Please contact repository administrators for assistance
 
 
-*Automated by the [PAC Boussole](https://github.com/openshift-pipelines/pac-boussole) 🧭* 
+*Automated by the [PAC Boussole](https://github.com/pipelines-as-code/pac-boussole) 🧭*
 
 """
 
@@ -125,7 +125,7 @@ Unable to process LGTM votes due to API error:
 3. Ensure the PR hasn't been closed or deleted
 
 
-*Automated by the [PAC Boussole](https://github.com/openshift-pipelines/pac-boussole) 🧭* 
+*Automated by the [PAC Boussole](https://github.com/pipelines-as-code/pac-boussole) 🧭*
 
 """
 
@@ -139,7 +139,7 @@ SELF_APPROVAL_ERROR = """
 Please wait for reviews from other team members.
 
 
-*Automated by the [PAC Boussole](https://github.com/openshift-pipelines/pac-boussole) 🧭* 
+*Automated by the [PAC Boussole](https://github.com/pipelines-as-code/pac-boussole) 🧭*
 
 """
 
@@ -151,7 +151,7 @@ The user @{pr_sender} is the author of this Pull Request.
 Nice try though! Authors reviewing their own code is like grading your own exam
 - tempting but defeats the purpose! 😉
 
-*Automated by the [PAC Boussole](https://github.com/openshift-pipelines/pac-boussole) 🧭* 
+*Automated by the [PAC Boussole](https://github.com/pipelines-as-code/pac-boussole) 🧭*
 """
 
 INSUFFICIENT_PERMISSIONS = """
@@ -163,19 +163,19 @@ INSUFFICIENT_PERMISSIONS = """
 
 Please request assistance from a repository maintainer.
 
-*Automated by the [PAC Boussole](https://github.com/openshift-pipelines/pac-boussole) 🧭* 
+*Automated by the [PAC Boussole](https://github.com/pipelines-as-code/pac-boussole) 🧭*
 """
 
 NOT_ENOUGH_LGTM = """
 ### ❌ Insufficient Approvals
 
-* Current valid LGTM votes: **{valid_votes}** 
+* Current valid LGTM votes: **{valid_votes}**
 * Required votes: **{threshold}**
 
 Please obtain additional approvals before merging.
 
 
-*Automated by the [PAC Boussole](https://github.com/openshift-pipelines/pac-boussole) 🧭* 
+*Automated by the [PAC Boussole](https://github.com/pipelines-as-code/pac-boussole) 🧭*
 
 """
 
@@ -186,14 +186,14 @@ Unable to merge PR #{pr_num}:
 * Status Code: `{status_code}`
 * Error: `{error_text}`
 
-*Possible causes:* 
+*Possible causes:*
 * Branch protection rules not satisfied
 * Merge conflicts present
 * Required checks failing
 
 Please resolve any issues and try again.
 
-*Automated by the [PAC Boussole](https://github.com/openshift-pipelines/pac-boussole) 🧭* 
+*Automated by the [PAC Boussole](https://github.com/pipelines-as-code/pac-boussole) 🧭*
 """
 
 # Add new error message template for cherry-pick
@@ -204,7 +204,7 @@ Failed to cherry-pick changes from PR #{source_pr} to branch `{target_branch}`:
 * Status Code: `{status_code}`
 * Error: `{error_text}`
 
-*Possible causes:* 
+*Possible causes:*
 * Merge conflicts
 * Branch protection rules
 * Invalid branch name
@@ -212,7 +212,7 @@ Failed to cherry-pick changes from PR #{source_pr} to branch `{target_branch}`:
 
 Please resolve any issues and try again.
 
-*Automated by the [PAC Boussole](https://github.com/openshift-pipelines/pac-boussole) 🧭* 
+*Automated by the [PAC Boussole](https://github.com/pipelines-as-code/pac-boussole) 🧭*
 
 """
 
@@ -221,14 +221,14 @@ CHERRY_PICK_SUCCESS = """
 
 Successfully cherry-picked changes from PR #{source_pr} to branch `{target_branch}`.
 
-*Details:* 
+*Details:*
 * Source PR: #{source_pr}
 * Target Branch: `{target_branch}`
 * Cherry-picked by: @{user}
 * New commit SHA: `{commit_sha}`
 
 
-*Automated by the [PAC Boussole](https://github.com/openshift-pipelines/pac-boussole) 🧭* 
+*Automated by the [PAC Boussole](https://github.com/pipelines-as-code/pac-boussole) 🧭*
 
 """
 
@@ -262,13 +262,13 @@ gh pr create --base {target_branch} --head YOURFORK:resolve-cherry-pick-{self.pr
 Need assistance? Please contact the repository maintainers.
 
 
-*Automated by the [PAC Boussole](https://github.com/openshift-pipelines/pac-boussole) 🧭* 
+*Automated by the [PAC Boussole](https://github.com/pipelines-as-code/pac-boussole) 🧭*
 
 """
 
 REVIEW_REQUESTED = """{greeting}
 
-🔍 @{submitter} has kindly requested your review on this PR. 
+🔍 @{submitter} has kindly requested your review on this PR.
 
 • Please review the changes and provide your feedback
 • Look for code quality, potential bugs, and overall design
@@ -281,7 +281,7 @@ appreciated.
 Thank you for your help! 🙌
 
 
-*Automated by the [PAC Boussole](https://github.com/openshift-pipelines/pac-boussole) 🧭* 
+*Automated by the [PAC Boussole](https://github.com/pipelines-as-code/pac-boussole) 🧭*
 
 """
 
@@ -293,5 +293,5 @@ CHECKS_NOT_PASSED = """⚠️ Cannot merge PR: Some required checks haven't comp
 🔍 Please ensure all checks pass before merging.
 💡 Tip: Review the failing checks above and address any issues.
 
-*Automated by the [PAC Boussole](https://github.com/openshift-pipelines/pac-boussole) 🧭* 
+*Automated by the [PAC Boussole](https://github.com/pipelines-as-code/pac-boussole) 🧭*
 """

--- a/boussole/test_boussole.py
+++ b/boussole/test_boussole.py
@@ -375,3 +375,70 @@ def test_assign_unassign_pr_author(pr_handler):
     with pytest.raises(SystemExit) as exc_info:
         pr_handler.assign_unassign("assign", ["test_user"])
         assert exc_info == 1
+
+
+def test_cherry_pick_open_pr(pr_handler, mock_api):
+    mock_api.get.return_value = MyFakeResponse(200, {"permission": "admin"})
+    mock_api.post.return_value.status_code = 200
+    pr_handler.cherry_pick(["release-1.0"])
+    mock_api.post.assert_called_with(
+        "issues/123/comments",
+        {"body": "✅ We will cherry-pick this PR to the branch `release-1.0` upon merge."},
+    )
+
+
+def test_cherry_pick_open_pr_insufficient_permissions(pr_handler, mock_api):
+    mock_api.get.return_value = MyFakeResponse(200, {"permission": "read"})
+    mock_api.post.return_value = MyFakeResponse(200, {})
+
+    with pytest.raises(SystemExit) as exc_info:
+        pr_handler.cherry_pick(["release-1.0"])
+    assert exc_info.value.code == 1
+
+
+def test_cherry_pick_invalid_args(pr_handler):
+    with pytest.raises(SystemExit) as exc_info:
+        pr_handler.cherry_pick(["branch1", "branch2"])
+    assert exc_info.value.code == 1
+
+
+def test_cherry_pick_immediate_success(pr_handler, mock_api):
+    commits = [
+        {"sha": "abc123", "commit": {"message": "fix: something"}},
+    ]
+    mock_responses = [
+        MyFakeResponse(200, {"permission": "admin"}),
+        MyFakeResponse(200, {"state": "closed", "merged": True, "base": {"ref": "main"}}),
+        MyFakeResponse(200, commits),
+        MyFakeResponse(200, {"object": {"sha": "target_sha"}}),
+    ]
+    mock_api.get.side_effect = mock_responses
+    mock_api.post.return_value = MyFakeResponse(201, {"sha": "new_sha"})
+
+    pr_handler.cherry_pick(["release-1.0"], immediate=True)
+
+    post_calls = mock_api.post.call_args_list
+    assert any(
+        "Cherry Pick Successful" in str(call) for call in post_calls
+    )
+
+
+def test_cherry_pick_immediate_closed_not_merged(pr_handler, mock_api):
+    mock_responses = [
+        MyFakeResponse(200, {"permission": "admin"}),
+        MyFakeResponse(200, {"state": "closed", "merged": False}),
+    ]
+    mock_api.get.side_effect = mock_responses
+
+    with pytest.raises(SystemExit) as exc_info:
+        pr_handler.cherry_pick(["release-1.0"], immediate=True)
+    assert exc_info.value.code == 1
+
+
+def test_cherry_pick_immediate_insufficient_permissions(pr_handler, mock_api):
+    mock_api.get.return_value = MyFakeResponse(200, {"permission": "read"})
+    mock_api.post.return_value = MyFakeResponse(200, {})
+
+    with pytest.raises(SystemExit) as exc_info:
+        pr_handler.cherry_pick(["release-1.0"], immediate=True)
+    assert exc_info.value.code == 1

--- a/boussole/test_main.py
+++ b/boussole/test_main.py
@@ -118,3 +118,115 @@ def test_main_invalid_command(monkeypatch):
     with pytest.raises(SystemExit):
         main()
     assert exit_code == 1
+
+
+def test_main_cherry_pick_on_merged_pr(monkeypatch):
+    cherry_pick_called = {}
+
+    def fake_check_status(self, num, status):
+        return status != "open"
+
+    def fake_get_pr_status(self, num):
+        class FakeResp:
+            status_code = 200
+
+            def json(self):
+                return {"state": "closed", "merged": True}
+
+        return FakeResp()
+
+    def fake_cherry_pick(self, values, immediate=False):
+        cherry_pick_called["values"] = values
+        cherry_pick_called["immediate"] = immediate
+
+    monkeypatch.setattr(PRHandler, "check_status", fake_check_status)
+    monkeypatch.setattr(PRHandler, "_get_pr_status", fake_get_pr_status)
+    monkeypatch.setattr(PRHandler, "cherry_pick", fake_cherry_pick)
+
+    sys.argv = [
+        "prog",
+        "--github-token",
+        "token",
+        "--pr-num",
+        "1",
+        "--pr-sender",
+        "user",
+        "--comment-sender",
+        "admin",
+        "--repo-owner",
+        "owner",
+        "--repo-name",
+        "repo",
+        "--trigger-comment",
+        "/cherry-pick release-1.0",
+        "--lgtm-threshold",
+        "1",
+        "--lgtm-permissions",
+        "admin,write",
+        "--lgtm-review-event",
+        "APPROVE",
+        "--merge-method",
+        "squash",
+    ]
+
+    main()
+    assert cherry_pick_called["values"] == ["release-1.0"]
+    assert cherry_pick_called["immediate"] is True
+
+
+def test_main_cherry_pick_on_closed_not_merged_pr(monkeypatch):
+    posted_comment = {}
+
+    def fake_check_status(self, num, status):
+        return status != "open"
+
+    def fake_get_pr_status(self, num):
+        class FakeResp:
+            status_code = 200
+
+            def json(self):
+                return {"state": "closed", "merged": False}
+
+        return FakeResp()
+
+    def fake_check_membership(self, user):
+        return "admin", True
+
+    def fake_post_comment(self, msg):
+        posted_comment["msg"] = msg
+
+    monkeypatch.setattr(PRHandler, "check_status", fake_check_status)
+    monkeypatch.setattr(PRHandler, "_get_pr_status", fake_get_pr_status)
+    monkeypatch.setattr(PRHandler, "_check_membership", fake_check_membership)
+    monkeypatch.setattr(PRHandler, "_post_comment", fake_post_comment)
+
+    sys.argv = [
+        "prog",
+        "--github-token",
+        "token",
+        "--pr-num",
+        "1",
+        "--pr-sender",
+        "user",
+        "--comment-sender",
+        "admin",
+        "--repo-owner",
+        "owner",
+        "--repo-name",
+        "repo",
+        "--trigger-comment",
+        "/cherry-pick release-1.0",
+        "--lgtm-threshold",
+        "1",
+        "--lgtm-permissions",
+        "admin,write",
+        "--lgtm-review-event",
+        "APPROVE",
+        "--merge-method",
+        "squash",
+    ]
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == 1
+    assert "closed but not merged" in posted_comment["msg"]

--- a/pipeline-boussole.yaml
+++ b/pipeline-boussole.yaml
@@ -32,7 +32,7 @@ spec:
       taskSpec:
         steps:
           - name: manage-pr
-            image: ghcr.io/openshift-pipelines/pac-boussole:nightly
+            image: ghcr.io/pipelines-as-code/pac-boussole:nightly
             env:
               - name: GITHUB_TOKEN
                 valueFrom:


### PR DESCRIPTION
## Summary

- `/cherry-pick target-branch` on a **merged PR** now immediately executes the cherry-pick instead of doing nothing
- Added permission check (admin/write) for `/cherry-pick` on both open and merged PRs
- Fixed `not in` → `!=` bug in `merge_pr()` that used substring matching instead of equality for sender comparison
- Fixed `{self.pr_num}` → `{pr_num}` in `CHERRY_PICK_CONFLICT` template so conflict messages render correctly

Fixes #37

## Changes
- ci: grant packages:write for GHCR push
- feat: allow cherry-pick on merged PRs
- chore: update repo URL and trim trailing whitespace

## Testing

TODO