### PR TITLE
feat: Add detailed help documentation for individual commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ automated actions.
 | `/merge [method]`            | Merges the PR if it has enough `/lgtm` approvals. Optional method: `merge`, `squash`, or `rebase` |
 | `/rebase`                    | Rebases the PR branch on the base branch                        |
 | `/help`                      | Displays available commands                                     |
+| `/help <command>`            | Displays syntax, examples, permissions, and effects for a command |
 
 > **Note:**
 >
@@ -42,6 +43,13 @@ automated actions.
 >   comment yet).
 > - The command must be at the start of the comment; any preceding text will be
 >   ignored.
+
+For focused usage details, request help for a specific command:
+
+```text
+/help merge
+/help cherry-pick
+```
 
 ## Usage
 

--- a/boussole/boussole.py
+++ b/boussole/boussole.py
@@ -22,6 +22,7 @@ from .messages import (  # isort:skip
     CHECKS_NOT_PASSED,
     COMMENTS_FETCH_ERROR,
     HELP_TEXT,
+    HELP_TOPIC_TEMPLATES,
     INSUFFICIENT_PERMISSIONS,
     LGTM_BREAKDOWN_TEMPLATE,
     MERGE_FAILED,
@@ -34,6 +35,7 @@ from .messages import (  # isort:skip
     CHERRY_PICK_SUCCESS,
     CHERRY_PICK_CONFLICT,
     REVIEW_REQUESTED,
+    UNKNOWN_HELP_TOPIC,
 )
 
 
@@ -76,6 +78,30 @@ class PRHandler:  # pylint: disable=too-many-instance-attributes
         """
         endpoint = f"issues/{self.pr_num}/comments"
         return self.api.post(endpoint, {"body": message})
+
+    def help(self, values: List[str]) -> RequestResponse:
+        """Posts general help or detailed help for one command."""
+        if not values:
+            return self._post_comment(HELP_TEXT.strip())
+
+        topic = values[0].lstrip("/").lower() if len(values) == 1 else " ".join(values)
+        template = HELP_TOPIC_TEMPLATES.get(topic) if len(values) == 1 else None
+        if template is None:
+            return self._post_comment(
+                UNKNOWN_HELP_TOPIC.format(
+                    topic=" ".join(values),
+                    general_help=HELP_TEXT.strip(),
+                ).strip()
+            )
+
+        return self._post_comment(
+            template.format(
+                threshold=self.lgtm_threshold,
+                permissions=", ".join(self.lgtm_permissions),
+                review_event=self.lgtm_review_event,
+                merge_method=self.merge_method,
+            ).strip()
+        )
 
     def _fetch_and_validate_lgtm_votes(self) -> Tuple[int, Dict[str, Optional[str]]]:
         """
@@ -810,7 +836,7 @@ def main():
     elif command == "rebase":
         response = pr_handler.rebase()
     elif command == "help":
-        response = pr_handler._post_comment(HELP_TEXT.strip())
+        response = pr_handler.help(values)
     elif command == "lgtm":
         pr_handler.lgtm()
     elif command == "merge":

--- a/boussole/messages.py
+++ b/boussole/messages.py
@@ -21,6 +21,116 @@ HELP_TEXT = f"""
 
 """
 
+HELP_TOPIC_TEMPLATES = {
+    "assign": """
+### `/assign` Help
+
+**Syntax:** `/assign user1 [user2 ...]`
+
+**Example:** `/assign octocat monalisa`
+
+**Permissions:** The configured GitHub token must be allowed to request reviewers.
+
+**Side effects:** Requests the listed users as reviewers and posts a review-request comment. The PR author cannot be assigned.
+""",
+    "unassign": """
+### `/unassign` Help
+
+**Syntax:** `/unassign user1 [user2 ...]`
+
+**Example:** `/unassign octocat monalisa`
+
+**Permissions:** The configured GitHub token must be allowed to manage requested reviewers.
+
+**Side effects:** Removes the listed users from the PR's requested reviewers and posts a confirmation comment.
+""",
+    "label": """
+### `/label` Help
+
+**Syntax:** `/label label1 [label2 ...]`
+
+**Example:** `/label bug needs-review`
+
+**Permissions:** The configured GitHub token must be allowed to manage issue and PR labels.
+
+**Side effects:** Adds the listed labels to the PR and posts a confirmation comment.
+""",
+    "unlabel": """
+### `/unlabel` Help
+
+**Syntax:** `/unlabel label1 [label2 ...]`
+
+**Example:** `/unlabel needs-review`
+
+**Permissions:** The configured GitHub token must be allowed to manage issue and PR labels.
+
+**Side effects:** Removes the listed labels from the PR and posts a confirmation comment.
+""",
+    "lgtm": """
+### `/lgtm` Help
+
+**Syntax:** `/lgtm`
+
+**Example:** `/lgtm`
+
+**Permissions:** A vote counts only when the reviewer has one of these repository permissions: `{permissions}`. Self-approval is rejected. The configured threshold is **{threshold}**.
+
+**Side effects:** Records the comment as an approval signal, submits a `{review_event}` review when configured, and posts the current vote breakdown.
+""",
+    "merge": """
+### `/merge` Help
+
+**Syntax:** `/merge [merge|squash|rebase]`
+
+**Examples:** `/merge` or `/merge squash`
+
+**Permissions:** The caller must have one of these repository permissions: `{permissions}`. The PR needs **{threshold}** valid approval(s), unless the configured direct-merge rules apply.
+
+**Side effects:** Verifies required checks and approvals, then merges with the requested method or the configured `{merge_method}` default. Any queued `/cherry-pick` requests are processed after the merge.
+""",
+    "cherry-pick": """
+### `/cherry-pick` Help
+
+**Syntax:** `/cherry-pick target-branch`
+
+**Example:** `/cherry-pick release-v1.2`
+
+**Permissions:** The configured GitHub token must be allowed to read commits and update the target branch.
+
+**Side effects:** Queues the PR commits to be cherry-picked to the target branch after the PR is merged. Conflicts require manual resolution.
+""",
+    "rebase": """
+### `/rebase` Help
+
+**Syntax:** `/rebase`
+
+**Example:** `/rebase`
+
+**Permissions:** The configured GitHub token and repository settings must allow the PR branch to be updated.
+
+**Side effects:** Requests GitHub to update the PR branch from its base branch and posts a confirmation comment.
+""",
+    "help": """
+### `/help` Help
+
+**Syntax:** `/help [command]`
+
+**Examples:** `/help` or `/help merge`
+
+**Permissions:** Any user who can trigger the Boussole pipeline may request help.
+
+**Side effects:** Posts either the general command table or detailed help for one command. It does not modify the PR.
+""",
+}
+
+UNKNOWN_HELP_TOPIC = """
+### Unknown Help Topic
+
+No detailed help is available for `{topic}`.
+
+{general_help}
+"""
+
 APPROVED_TEMPLATE = """
 Congrats @{pr_sender} your PR Has been approved 🎉
 

--- a/boussole/test_main.py
+++ b/boussole/test_main.py
@@ -5,6 +5,34 @@ import pytest
 from boussole.boussole import PRHandler, main  # Import main and PRHandler
 
 
+def main_args(trigger_comment):
+    return [
+        "prog",
+        "--github-token",
+        "token",
+        "--pr-num",
+        "1",
+        "--pr-sender",
+        "user",
+        "--comment-sender",
+        "admin",
+        "--repo-owner",
+        "owner",
+        "--repo-name",
+        "repo",
+        "--trigger-comment",
+        trigger_comment,
+        "--lgtm-threshold",
+        "1",
+        "--lgtm-permissions",
+        "admin,write",
+        "--lgtm-review-event",
+        "APPROVE",
+        "--merge-method",
+        "squash",
+    ]
+
+
 # Dummy response to simulate successful API call.
 class DummyResponse:
     """
@@ -40,31 +68,7 @@ def test_main_help_success(monkeypatch, capsys):
     monkeypatch.setattr(PRHandler, "check_response", lambda self, resp: True)
 
     # Set sys.argv with valid parameters and a trigger comment for "help".
-    sys.argv = [
-        "prog",
-        "--github-token",
-        "token",
-        "--pr-num",
-        "1",
-        "--pr-sender",
-        "user",
-        "--comment-sender",
-        "admin",
-        "--repo-owner",
-        "owner",
-        "--repo-name",
-        "repo",
-        "--trigger-comment",
-        "/help",
-        "--lgtm-threshold",
-        "1",
-        "--lgtm-permissions",
-        "admin,write",
-        "--lgtm-review-event",
-        "APPROVE",
-        "--merge-method",
-        "squash",
-    ]
+    sys.argv = main_args("/help")
 
     # Call main; expecting it to complete without sys.exit
     try:
@@ -80,31 +84,7 @@ def test_main_help_success(monkeypatch, capsys):
 # Test for the main function with an invalid command.
 def test_main_invalid_command(monkeypatch):
     # Set sys.argv with a trigger comment that does not match a valid command.
-    sys.argv = [
-        "prog",
-        "--github-token",
-        "token",
-        "--pr-num",
-        "1",
-        "--pr-sender",
-        "user",
-        "--comment-sender",
-        "admin",
-        "--repo-owner",
-        "owner",
-        "--repo-name",
-        "repo",
-        "--trigger-comment",
-        "/invalidcmd",
-        "--lgtm-threshold",
-        "1",
-        "--lgtm-permissions",
-        "admin,write",
-        "--lgtm-review-event",
-        "APPROVE",
-        "--merge-method",
-        "squash",
-    ]
+    sys.argv = main_args("/invalidcmd")
     # Monkey-patch sys.exit to capture the exit code.
     exit_code = None
 
@@ -118,3 +98,44 @@ def test_main_invalid_command(monkeypatch):
     with pytest.raises(SystemExit):
         main()
     assert exit_code == 1
+
+
+@pytest.mark.parametrize(
+    ("trigger_comment", "expected"),
+    [
+        ("/help merge", "Syntax:"),
+        ("/help /lgtm", "Self-approval is rejected"),
+    ],
+)
+def test_main_command_specific_help(monkeypatch, trigger_comment, expected):
+    dummy = DummyResponse(200, "OK")
+
+    def fake_post_comment(_, message):
+        assert expected in message
+        assert "Permissions:" in message
+        assert "Side effects:" in message
+        return dummy
+
+    monkeypatch.setattr(PRHandler, "_post_comment", fake_post_comment)
+    monkeypatch.setattr(PRHandler, "check_status", lambda self, *_: True)
+    monkeypatch.setattr(PRHandler, "check_response", lambda self, resp: True)
+    sys.argv = main_args(trigger_comment)
+
+    main()
+
+
+@pytest.mark.parametrize("trigger_comment", ["/help frobnicate", "/help merge now"])
+def test_main_unknown_help_topic(monkeypatch, trigger_comment):
+    dummy = DummyResponse(200, "OK")
+
+    def fake_post_comment(_, message):
+        assert "Unknown Help Topic" in message
+        assert "Available Commands" in message
+        return dummy
+
+    monkeypatch.setattr(PRHandler, "_post_comment", fake_post_comment)
+    monkeypatch.setattr(PRHandler, "check_status", lambda self, *_: True)
+    monkeypatch.setattr(PRHandler, "check_response", lambda self, resp: True)
+    sys.argv = main_args(trigger_comment)
+
+    main()


### PR DESCRIPTION
Implemented command-specific help messages for all available commands to
improve user guidance. Added templates detailing syntax, examples,
permissions, and side effects, and updated tests to cover the new help
functionality.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>
